### PR TITLE
Add logic for upserting ownerships

### DIFF
--- a/web3indexer/crud.py
+++ b/web3indexer/crud.py
@@ -2,7 +2,7 @@ import structlog
 
 from pymongo.database import Database
 
-from .models import Contract, Nft, Transfer
+from .models import Contract, Nft, UpsertOwnership, Transfer
 from .utils import get_nft_id, get_transfer_id
 
 
@@ -74,6 +74,25 @@ def upsert_nft(db: Database, nft: Nft):
     db.nfts.find_one_and_update(
         {"_id": nft_id},
         {"$set": {**nft.dict()}},
+        upsert=True,
+    )
+
+
+def upsert_ownership(db: Database, upsert_ownership: UpsertOwnership):
+    # TODO: Need to check if `block_number` and `log_index` have already
+    # been processed to ensure we don't update unnecessarily
+    db.ownerships.find_one_and_update(
+        {
+            "nft_id": upsert_ownership.nft_id,
+            "owner": upsert_ownership.owner,
+        },
+        {
+            "$set": {
+                "nft_id": upsert_ownership.nft_id,
+                "owner": upsert_ownership.owner,
+            },
+            "$inc": {"quantity": upsert_ownership.delta_quantity},
+        },
         upsert=True,
     )
 

--- a/web3indexer/models.py
+++ b/web3indexer/models.py
@@ -20,6 +20,7 @@ class Contract(BaseModel):
         allow_population_by_field_name = True
 
 
+# TODO: Add minted_at, is_burned fields
 class Nft(BaseModel):
     contract_id: str
     token_id: int
@@ -37,3 +38,11 @@ class Transfer(BaseModel):
 
     class Config:
         allow_population_by_field_name = True
+
+
+class UpsertOwnership(BaseModel):
+    block_number: int
+    delta_quantity: int
+    log_index: int
+    nft_id: str
+    owner: str


### PR DESCRIPTION
This PR adds logic to also track NFT ownerships inside `log_processor.py`. This is a very simple and naive implementation that doesn't properly handle:

- What happens if we process blocks/logs out of order?
- What happens if we re-process blocks/logs?

I haven't found a good answer yet, I'm curious if folks know what Rarible does?